### PR TITLE
Support upper and lower bounds for wildcard types

### DIFF
--- a/core/src/main/java/io/github/muehmar/pojobuilder/generator/model/type/Types.java
+++ b/core/src/main/java/io/github/muehmar/pojobuilder/generator/model/type/Types.java
@@ -91,6 +91,18 @@ public class Types {
     return new Type(TypeVariableType.ofName(name));
   }
 
+  public static Type wildcard() {
+    return new Type(WildcardType.create());
+  }
+
+  public static Type wildcardUpperBound(Type bound) {
+    return new Type(WildcardType.upperBound(bound));
+  }
+
+  public static Type wildcardLowerBound(Type bound) {
+    return new Type(WildcardType.lowerBound(bound));
+  }
+
   public static Type declaredType(Classname name, PackageName pkg) {
     return new Type(DeclaredType.fromNameAndPackage(name, pkg));
   }

--- a/core/src/main/java/io/github/muehmar/pojobuilder/generator/model/type/WildcardType.java
+++ b/core/src/main/java/io/github/muehmar/pojobuilder/generator/model/type/WildcardType.java
@@ -2,16 +2,31 @@ package io.github.muehmar.pojobuilder.generator.model.type;
 
 import ch.bluecare.commons.data.PList;
 import io.github.muehmar.pojobuilder.generator.model.Name;
+import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
 @EqualsAndHashCode
 @ToString
 public class WildcardType implements SpecificType {
-  private WildcardType() {}
+  private final Optional<Type> upperBound;
+  private final Optional<Type> lowerBound;
+
+  private WildcardType(Optional<Type> upperBound, Optional<Type> lowerBound) {
+    this.upperBound = upperBound;
+    this.lowerBound = lowerBound;
+  }
 
   public static WildcardType create() {
-    return new WildcardType();
+    return new WildcardType(Optional.empty(), Optional.empty());
+  }
+
+  public static WildcardType upperBound(Type bound) {
+    return new WildcardType(Optional.of(bound), Optional.empty());
+  }
+
+  public static WildcardType lowerBound(Type bound) {
+    return new WildcardType(Optional.empty(), Optional.of(bound));
   }
 
   @Override
@@ -26,11 +41,18 @@ public class WildcardType implements SpecificType {
 
   @Override
   public Name getTypeDeclaration() {
+    if (upperBound.isPresent()) {
+      return Name.fromString("? extends " + upperBound.get().getTypeDeclaration().asString());
+    } else if (lowerBound.isPresent()) {
+      return Name.fromString("? super " + lowerBound.get().getTypeDeclaration().asString());
+    }
     return Name.fromString("?");
   }
 
   @Override
   public PList<Name> getImports() {
-    return PList.empty();
+    return upperBound
+        .map(Type::getImports)
+        .orElseGet(() -> lowerBound.map(Type::getImports).orElse(PList.empty()));
   }
 }

--- a/core/src/main/java/io/github/muehmar/pojobuilder/processor/mapper/TypeMirrorMapper.java
+++ b/core/src/main/java/io/github/muehmar/pojobuilder/processor/mapper/TypeMirrorMapper.java
@@ -49,6 +49,7 @@ public class TypeMirrorMapper {
         declaredTypeMapper(),
         arrayTypeMapper(),
         typeVariableMapper(),
+        wildcardTypeMapper(),
         Mapper.forFixMapping(BOOLEAN, Types.primitiveBoolean()),
         Mapper.forFixMapping(CHAR, Types.primitiveChar()),
         Mapper.forFixMapping(INT, Types.primitiveInt()),
@@ -57,8 +58,7 @@ public class TypeMirrorMapper {
         Mapper.forFixMapping(LONG, Types.primitiveLong()),
         Mapper.forFixMapping(SHORT, Types.primitiveShort()),
         Mapper.forFixMapping(BYTE, Types.primitiveByte()),
-        Mapper.forFixMapping(VOID, Types.voidType()),
-        Mapper.forFixMapping(WILDCARD, Type.fromSpecificType(WildcardType.create())));
+        Mapper.forFixMapping(VOID, Types.voidType()));
   }
 
   private static Mapper declaredTypeMapper() {
@@ -87,6 +87,23 @@ public class TypeMirrorMapper {
         TypeKind.TYPEVAR,
         TypeVariable.class,
         typeVariable -> Types.typeVariable(Name.fromString(typeVariable.toString())));
+  }
+
+  private static Mapper wildcardTypeMapper() {
+    return Mapper.forKindAndClass(
+        WILDCARD,
+        javax.lang.model.type.WildcardType.class,
+        wildcardType -> {
+          final TypeMirror extendsBound = wildcardType.getExtendsBound();
+          final TypeMirror superBound = wildcardType.getSuperBound();
+          if (extendsBound != null) {
+            return Type.fromSpecificType(WildcardType.upperBound(map(extendsBound)));
+          } else if (superBound != null) {
+            return Type.fromSpecificType(WildcardType.lowerBound(map(superBound)));
+          } else {
+            return Type.fromSpecificType(WildcardType.create());
+          }
+        });
   }
 
   private static class Mapper {

--- a/core/src/test/java/io/github/muehmar/pojobuilder/generator/model/type/WildcardTypeTest.java
+++ b/core/src/test/java/io/github/muehmar/pojobuilder/generator/model/type/WildcardTypeTest.java
@@ -1,0 +1,69 @@
+package io.github.muehmar.pojobuilder.generator.model.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.bluecare.commons.data.PList;
+import io.github.muehmar.pojobuilder.generator.model.Name;
+import org.junit.jupiter.api.Test;
+
+class WildcardTypeTest {
+
+  @Test
+  void getTypeDeclaration_when_unbounded_then_returnsQuestionMark() {
+    final WildcardType wildcardType = WildcardType.create();
+    assertThat(wildcardType.getTypeDeclaration().asString()).isEqualTo("?");
+  }
+
+  @Test
+  void getTypeDeclaration_when_upperBound_then_returnsExtendsDeclaration() {
+    final WildcardType wildcardType = WildcardType.upperBound(Types.integer());
+    assertThat(wildcardType.getTypeDeclaration().asString()).isEqualTo("? extends Integer");
+  }
+
+  @Test
+  void getTypeDeclaration_when_lowerBound_then_returnsSuperDeclaration() {
+    final WildcardType wildcardType = WildcardType.lowerBound(Types.string());
+    assertThat(wildcardType.getTypeDeclaration().asString()).isEqualTo("? super String");
+  }
+
+  @Test
+  void getTypeDeclaration_when_upperBoundWithGenericType_then_returnsCorrectDeclaration() {
+    final Type listOfString = Types.list(Types.string());
+    final WildcardType wildcardType = WildcardType.upperBound(listOfString);
+    assertThat(wildcardType.getTypeDeclaration().asString()).isEqualTo("? extends List<String>");
+  }
+
+  @Test
+  void getImports_when_unbounded_then_returnsEmpty() {
+    final WildcardType wildcardType = WildcardType.create();
+    assertThat(wildcardType.getImports()).isEqualTo(PList.empty());
+  }
+
+  @Test
+  void getImports_when_upperBoundWithImport_then_returnsBoundImports() {
+    final Type listOfString = Types.list(Types.string());
+    final WildcardType wildcardType = WildcardType.upperBound(listOfString);
+    assertThat(wildcardType.getImports())
+        .containsExactly(Name.fromString("java.util.List"), Name.fromString("java.lang.String"));
+  }
+
+  @Test
+  void getImports_when_lowerBoundWithImport_then_returnsBoundImports() {
+    final Type listOfString = Types.list(Types.string());
+    final WildcardType wildcardType = WildcardType.lowerBound(listOfString);
+    assertThat(wildcardType.getImports())
+        .containsExactly(Name.fromString("java.util.List"), Name.fromString("java.lang.String"));
+  }
+
+  @Test
+  void getName_when_anyWildcard_then_returnsQuestionMark() {
+    assertThat(WildcardType.create().getName().asString()).isEqualTo("?");
+    assertThat(WildcardType.upperBound(Types.string()).getName().asString()).isEqualTo("?");
+    assertThat(WildcardType.lowerBound(Types.string()).getName().asString()).isEqualTo("?");
+  }
+
+  @Test
+  void getKind_when_called_then_returnsWildcard() {
+    assertThat(WildcardType.create().getKind()).isEqualTo(TypeKind.WILDCARD);
+  }
+}

--- a/example-java17/src/main/java/io/github/muehmar/pojobuilder/example/SampleRecord.java
+++ b/example-java17/src/main/java/io/github/muehmar/pojobuilder/example/SampleRecord.java
@@ -1,7 +1,9 @@
 package io.github.muehmar.pojobuilder.example;
 
 import io.github.muehmar.pojobuilder.annotations.PojoBuilder;
+import java.util.Collection;
 import java.util.Optional;
 
 @PojoBuilder
-public record SampleRecord(long id, String name, Optional<String> data) {}
+public record SampleRecord(
+    long id, String name, Optional<String> data, Collection<? extends Number> numbers) {}

--- a/example-java17/src/test/java/io/github/muehmar/pojobuilder/example/SampleRecordTest.java
+++ b/example-java17/src/test/java/io/github/muehmar/pojobuilder/example/SampleRecordTest.java
@@ -2,6 +2,7 @@ package io.github.muehmar.pojobuilder.example;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ class SampleRecordTest {
         SampleRecordBuilder.create()
             .id(12L)
             .name("name")
+            .numbers(List.of(1, 2, 3))
             .andAllOptionals()
             .data("Hello World!")
             .build();
@@ -19,5 +21,6 @@ class SampleRecordTest {
     assertThat(sampleRecord.id()).isEqualTo(12L);
     assertThat(sampleRecord.name()).isEqualTo("name");
     assertThat(sampleRecord.data()).isEqualTo(Optional.of("Hello World!"));
+    assertThat(sampleRecord.numbers()).isEqualTo(List.of(1, 2, 3));
   }
 }


### PR DESCRIPTION
Add support for bounded wildcards. See extended example for reproducing the error:

```
> Task :example-java17:compileJava FAILED
./pojo-builder/example-java17/build/generated/sources/annotationProcessor/java/main/io/github/muehmar/pojobuilder/example/SampleRecordBuilder.java:63: error: incompatible types: Collection<CAP#1> cannot be converted to Collection<? extends Number>
        new SampleRecord(id, name, Optional.ofNullable(data), numbers);
                                                              ^
  where CAP#1 is a fresh type-variable:
    CAP#1 extends Object from capture of ?
./pojo-builder/example-java17/build/generated/sources/annotationProcessor/java/main/io/github/muehmar/pojobuilder/example/SampleRecordBuilder.java:103: error: incompatible types: Collection<CAP#1> cannot be converted to Collection<? extends Number>
          new SampleRecord(id, name, Optional.ofNullable(data), numbers);
                                                                ^
  where CAP#1 is a fresh type-variable:
    CAP#1 extends Object from capture of ?
```

Before:

```java
public final class SampleRecordBuilder {

  // ...

  private long id;
  private String name;
  private String data;
  private Collection<?> numbers;

  private SampleRecordBuilder(long id, String name, String data, Collection<?> numbers) {
    this.id = id;
    this.name = name;
    this.data = data;
    this.numbers = numbers;
  }

  // ...

}
```

After:

```java
public final class SampleRecordBuilder {

  // ...

  private long id;
  private String name;
  private String data;
  private Collection<? extends Number> numbers;

  private SampleRecordBuilder(long id, String name, String data, Collection<? extends Number> numbers) {
    this.id = id;
    this.name = name;
    this.data = data;
    this.numbers = numbers;
  }

  // ...

}
```